### PR TITLE
Round current player fix

### DIFF
--- a/lib/src/scopa_round.dart
+++ b/lib/src/scopa_round.dart
@@ -13,7 +13,8 @@ class ScopaRound {
   var _currentPlayerIndex = 0;
 
   /// The [Player] that the next call to [play] will use.
-  Player? get currentPlayer => _table.seats[_currentPlayerIndex].player;
+  Player? get currentPlayer =>
+      _table.seats.isNotEmpty ? _table.seats[_currentPlayerIndex].player : null;
 
   ScopaRound(this._manager, this._table) {
     for (final seat in _table.seats) {

--- a/test/scopa_round_test.dart
+++ b/test/scopa_round_test.dart
@@ -181,6 +181,12 @@ void main() {
 
           expect(roundState, equals(RoundState.ending));
         });
+
+        test('an ending result when there are no players', () {
+          final round = getTestRound(0).$1;
+
+          expect(round.play(Card('Denari', 2)), equals(RoundState.ending));
+        });
       });
     });
   });

--- a/test/scopa_round_test.dart
+++ b/test/scopa_round_test.dart
@@ -132,6 +132,12 @@ void main() {
         expect(round.currentPlayer, isNot(firstPlayer));
       });
 
+      test('sets the current player as null if there are no players', () {
+        final round = getTestRound(0).$1;
+
+        expect(round.currentPlayer, isNull);
+      });
+
       test(
           'throws an argument error if match cards are not summed to the play card',
           () {


### PR DESCRIPTION
Clarifies why ScopaRound.currentPlayer can be null.
Fixes an error when trying to access currentlyPlayer while the round table has no players.